### PR TITLE
Make output-path optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ GitHub action to strip HTML tags from a Markdown file.
 
 * `input-path` (mandatory): Path to the input Markdown file that contains some HTML.
 
-* `output-path` (mandatory): Path to the output Markdown file stripped of HTML.  
-    May be equal to `input-path` to modify the file in place.
+* `output-path` (optional): Path to the output Markdown file stripped of HTML.  
+    If unspecified, use `input-path`, ie modify the file in place.
 
 * `encoding` (optional): The text encoding of the file. Default: `utf8`.

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,8 @@ inputs:
     required: true
   output-path:
     description: 'Path to the output markdown file'
-    required: true
+    required: false
+    default:
   encoding:
     description: 'The file encoding to use'
     required: false

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const strip = require('remark-strip-html');
 
 try {
   const inputPath = core.getInput('input-path');
-  const outputPath = core.getInput('output-path');
+  const outputPath = core.getInput('output-path') || inputPath;
   const encoding = core.getInput('encoding');
 
   const inputText = fs.readFileSync(inputPath, encoding);


### PR DESCRIPTION
If output-path is not provided, modify the file in place.